### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/4clojure.el
+++ b/4clojure.el
@@ -96,7 +96,7 @@ clobber existing text in the buffer (if the problem was already opened)."
     ; only add to empty buffers, thanks: http://stackoverflow.com/q/18312897
     (when (= 0 (buffer-size buffer))
       (insert (4clojure/format-problem-for-buffer problem-number description questions restrictions))
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (search-forward "__")
       (backward-char 2)
       (when (functionp 'clojure-mode)

--- a/4clojure.el
+++ b/4clojure.el
@@ -143,7 +143,7 @@ named something like *blah-blah-123*"
                                     (1- (string-width number-with-star)))))
     (if (string-match "[^0-9]" problem-number)
         0
-      (string-to-int problem-number))))
+      (string-to-number problem-number))))
 
 (defun 4clojure/check-answer (problem-number answer)
   "Sends an answer to 4clojure and returns the result"


### PR DESCRIPTION
Hi! Thanks to deverop such a great package!

I found below byte-compile warnings and fix them.

```
Compiling file /Users/conao/.emacs.d/local/26.2/elpa/4clojure-20131015.707/4clojure.el at Wed Jul  3 04:25:39 2019
Entering directory ‘/Users/conao/.emacs.d/local/26.2/elpa/4clojure-20131015.707/’

  In 4clojure/start-new-problem:
  4clojure.el:99:51:Warning: ‘beginning-of-buffer’ is for interactive use only;
  use ‘(goto-char (point-min))’ instead.
  
  In 4clojure/check-answer:
  4clojure.el:166:3:Warning: assignment to free variable ‘result’
  4clojure.el:166:3:Warning: reference to free variable ‘result’
  
  In end of data:
  4clojure.el:211:1:Warning: the function ‘string-to-int’ is not known to be defined.
```

but assigning free variable warnings still remained.